### PR TITLE
Improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/mhausenblas/rback
 go 1.12
 
 require (
-	github.com/emicklei/dot v0.9.3
-	github.com/mhausenblas/kubecuddler v0.0.0-20181012110128-5836f3e4e7d0 // indirect
+	github.com/emicklei/dot v0.10.0
+	github.com/mhausenblas/kubecuddler v0.0.0-20181012110128-5836f3e4e7d0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/emicklei/dot v0.9.3 h1:w5L9uYR6o6Bj7ZyfzbSFnMdQJBU89zfs9emxaLa0svI=
-github.com/emicklei/dot v0.9.3/go.mod h1:kZg82Ikwc4pqb31Ct2yb0B7RUqxh3JESIXw2uWSv/xY=
+github.com/emicklei/dot v0.10.0 h1:BAuTQEJM56bu8Z0+d073CPJrc9I8gj4uXCKDIO0Cwpk=
+github.com/emicklei/dot v0.10.0/go.mod h1:kZg82Ikwc4pqb31Ct2yb0B7RUqxh3JESIXw2uWSv/xY=
 github.com/mhausenblas/kubecuddler v0.0.0-20181012110128-5836f3e4e7d0 h1:TZSzAlXKCKnstV6euLVFkwI4gHudDPoLqq3/kBaR3PI=
 github.com/mhausenblas/kubecuddler v0.0.0-20181012110128-5836f3e4e7d0/go.mod h1:6FIXVGLaL5pg6GSkmkDEY1TaRCNySC7DdR+/PF0OClo=

--- a/main.go
+++ b/main.go
@@ -378,9 +378,9 @@ func (r *Rback) renderLegend(g *dot.Graph) {
 
 	sa := newServiceAccountNode(namespace, "ServiceAccount")
 
-	role := newRoleNode(namespace, "Role")
-	clusterRoleBoundLocally := newClusterRoleNode(namespace, "ClusterRole") // bound by (namespaced!) RoleBinding
-	clusterrole := newClusterRoleNode(legend, "ClusterRole")
+	role := newRoleNode(namespace, "ns", "Role")
+	clusterRoleBoundLocally := newClusterRoleNode(namespace, "ns", "ClusterRole") // bound by (namespaced!) RoleBinding
+	clusterrole := newClusterRoleNode(legend, "", "ClusterRole")
 
 	if r.config.renderBindings {
 		roleBinding := newRoleBindingNode(namespace, "RoleBinding")
@@ -416,9 +416,9 @@ func (r *Rback) renderRole(g *dot.Graph, binding, role NamespacedName, saNode do
 
 	isClusterRole := role.namespace == ""
 	if isClusterRole {
-		roleNode = newClusterRoleNode(g, role.name)
+		roleNode = newClusterRoleNode(g, binding.namespace, role.name)
 	} else {
-		roleNode = newRoleNode(g, role.name)
+		roleNode = newRoleNode(g, binding.namespace, role.name)
 	}
 
 	if r.config.renderBindings {
@@ -483,8 +483,8 @@ func newClusterRoleBindingNode(g *dot.Graph, name string) dot.Node {
 		Attr("fontcolor", "#030303")
 }
 
-func newRoleNode(g *dot.Graph, name string) dot.Node {
-	return g.Node("r-"+name).
+func newRoleNode(g *dot.Graph, namespace, name string) dot.Node {
+	return g.Node("r-"+namespace+"/"+name).
 		Attr("label", name).
 		Attr("shape", "octagon").
 		Attr("style", "filled").
@@ -492,8 +492,8 @@ func newRoleNode(g *dot.Graph, name string) dot.Node {
 		Attr("fontcolor", "#030303")
 }
 
-func newClusterRoleNode(g *dot.Graph, name string) dot.Node {
-	return g.Node("cr-"+name).
+func newClusterRoleNode(g *dot.Graph, namespace, name string) dot.Node {
+	return g.Node("cr-"+namespace+"/"+name).
 		Attr("label", name).
 		Attr("shape", "doubleoctagon").
 		Attr("style", "filled").

--- a/main.go
+++ b/main.go
@@ -560,7 +560,10 @@ func newClusterRoleNode(g *dot.Graph, namespace, name string) dot.Node {
 }
 
 func newRulesNode(g *dot.Graph, namespace, roleName, rules string) dot.Node {
+	rules = strings.ReplaceAll(rules, `\`, `\\`)
+	rules = strings.ReplaceAll(rules, "\n", `\l`) // left-justify text
+	rules = strings.ReplaceAll(rules, `"`, `\"`)  // using Literal, so we need to escape quotes
 	return g.Node("rules-"+namespace+"/"+roleName).
-		Attr("label", rules).
+		Attr("label", dot.Literal(`"`+rules+`"`)).
 		Attr("shape", "note")
 }

--- a/main.go
+++ b/main.go
@@ -351,7 +351,7 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 				os.Exit(-2)
 			}
 			for _, crole := range croles {
-				r.renderRole(g, crole.binding, crole.role, sanode, p, "")
+				r.renderRole(g, crole.binding, crole.role, sanode, p)
 			}
 			// roles:
 			roles, err := r.lookupBindingsAndRoles(p.RoleBindings[ns], sa)
@@ -360,7 +360,7 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 				os.Exit(-2)
 			}
 			for _, role := range roles {
-				r.renderRole(gns, role.binding, role.role, sanode, p, ns)
+				r.renderRole(gns, role.binding, role.role, sanode, p)
 			}
 
 		}
@@ -396,7 +396,7 @@ func (r *Rback) renderLegend(g *dot.Graph) {
 	}
 }
 
-func (r *Rback) renderRole(g *dot.Graph, binding, role NamespacedName, saNode dot.Node, p Permissions, ns string) {
+func (r *Rback) renderRole(g *dot.Graph, binding, role NamespacedName, saNode dot.Node, p Permissions) {
 	var roleNode dot.Node
 
 	isClusterRole := role.namespace == ""
@@ -408,7 +408,7 @@ func (r *Rback) renderRole(g *dot.Graph, binding, role NamespacedName, saNode do
 	g.Edge(saNode, roleNode, binding.name)
 
 	if r.config.renderRules {
-		res, err := r.lookupResources(ns, role.name, p)
+		res, err := r.lookupResources(binding.namespace, role.name, p)
 		if err != nil {
 			fmt.Printf("Can't look up entities and resources due to: %v", err)
 			os.Exit(-3)

--- a/main.go
+++ b/main.go
@@ -454,6 +454,30 @@ func (r *Rback) genGraph() *dot.Graph {
 		}
 	}
 
+	// draw any additional Roles that weren't referenced by bindings (and thus already drawn)
+	for ns, roles := range r.permissions.Roles {
+		var renderRoles bool
+
+		areClusterRoles := ns == ""
+		if areClusterRoles {
+			renderRoles = (r.config.resourceKind == "" || r.config.resourceKind == "clusterrole") && r.allNamespaces()
+		} else {
+			renderRoles = (r.config.resourceKind == "" || r.config.resourceKind == "role") && r.namespaceSelected(ns)
+		}
+
+		if !renderRoles {
+			continue
+		}
+
+		gns := r.newNamespaceSubgraph(g, ns)
+		for roleName, _ := range roles {
+			renderRole := r.namespaceSelected(ns) && r.resourceNameSelected(roleName)
+			if renderRole {
+				r.newRoleAndRulesNodePair(gns, "", NamespacedName{ns, roleName})
+			}
+		}
+	}
+
 	return g
 }
 

--- a/main.go
+++ b/main.go
@@ -478,14 +478,17 @@ func (r *Rback) renderLegend(g *dot.Graph) {
 	clusterrole := newClusterRoleNode(legend, "", "ClusterRole")
 
 	roleBinding := newRoleBindingNode(namespace, "RoleBinding")
-	sa.Edge(roleBinding).Edge(role)
+	sa.Edge(roleBinding).Attr("dir", "back")
+	roleBinding.Edge(role)
 
 	roleBinding2 := newRoleBindingNode(namespace, "RoleBinding-to-ClusterRole")
 	roleBinding2.Attr("label", "RoleBinding")
-	sa.Edge(roleBinding2).Edge(clusterRoleBoundLocally)
+	sa.Edge(roleBinding2).Attr("dir", "back")
+	roleBinding2.Edge(clusterRoleBoundLocally)
 
 	clusterRoleBinding := newClusterRoleBindingNode(legend, "ClusterRoleBinding")
-	sa.Edge(clusterRoleBinding).Edge(clusterrole)
+	sa.Edge(clusterRoleBinding).Attr("dir", "back")
+	clusterRoleBinding.Edge(clusterrole)
 
 	if r.config.renderRules {
 		nsrules := newRulesNode(namespace, "ns", "Role", "Namespace-scoped\naccess rules")
@@ -519,7 +522,7 @@ func (r *Rback) renderRole(g *dot.Graph, binding, role NamespacedName, saNodes [
 	}
 	roleBindingNode.Edge(roleNode)
 	for _, saNode := range saNodes {
-		saNode.Edge(roleBindingNode)
+		saNode.Edge(roleBindingNode).Attr("dir", "back")
 	}
 
 	if r.config.renderRules {

--- a/main.go
+++ b/main.go
@@ -659,7 +659,7 @@ func (r *Rback) newClusterRoleBindingNode(g *dot.Graph, name string, highlight b
 }
 
 func (r *Rback) newRoleNode(g *dot.Graph, namespace, name string, exists, highlight bool) dot.Node {
-	return g.Node("r-"+namespace+"/"+name).
+	node := g.Node("r-"+namespace+"/"+name).
 		Attr("label", name).
 		Attr("shape", "octagon").
 		Attr("style", iff(exists, "filled", "dotted")).
@@ -667,10 +667,12 @@ func (r *Rback) newRoleNode(g *dot.Graph, namespace, name string, exists, highli
 		Attr("penwidth", iff(highlight || !exists, "2.0", "1.0")).
 		Attr("fillcolor", "#ff9900").
 		Attr("fontcolor", "#030303")
+	g.Root().AddToSameRank("Roles", node)
+	return node
 }
 
 func (r *Rback) newClusterRoleNode(g *dot.Graph, bindingNamespace, roleName string, exists, highlight bool) dot.Node {
-	return g.Node("cr-"+bindingNamespace+"/"+roleName).
+	node := g.Node("cr-"+bindingNamespace+"/"+roleName).
 		Attr("label", roleName).
 		Attr("shape", "doubleoctagon").
 		Attr("style", iff(exists, iff(bindingNamespace == "", "filled", "filled,dashed"), "dotted")).
@@ -678,6 +680,8 @@ func (r *Rback) newClusterRoleNode(g *dot.Graph, bindingNamespace, roleName stri
 		Attr("penwidth", iff(highlight || !exists, "2.0", "1.0")).
 		Attr("fillcolor", "#ff9900").
 		Attr("fontcolor", "#030303")
+	g.Root().AddToSameRank("Roles", node)
+	return node
 }
 
 func (r *Rback) isFocused(kind string, ns string, name string) bool {

--- a/main.go
+++ b/main.go
@@ -479,7 +479,9 @@ func (r *Rback) shouldRenderBinding(binding Binding) bool {
 			r.resourceNameSelected(binding.role.name) &&
 			r.roleExists(binding.role)
 	case "clusterrole":
-		return (binding.role.namespace == "" || r.namespaceSelected(binding.role.namespace)) && r.resourceNameSelected(binding.role.name)
+		return (binding.role.namespace == "" || r.namespaceSelected(binding.role.namespace)) &&
+			r.resourceNameSelected(binding.role.name) &&
+			r.roleExists(binding.role)
 	}
 	return false
 }

--- a/main.go
+++ b/main.go
@@ -475,7 +475,9 @@ func (r *Rback) shouldRenderBinding(binding Binding) bool {
 			}
 		}
 	case "role":
-		return r.namespaceSelected(binding.role.namespace) && r.resourceNameSelected(binding.role.name)
+		return r.namespaceSelected(binding.role.namespace) &&
+			r.resourceNameSelected(binding.role.name) &&
+			r.roleExists(binding.role)
 	case "clusterrole":
 		return (binding.role.namespace == "" || r.namespaceSelected(binding.role.namespace)) && r.resourceNameSelected(binding.role.name)
 	}

--- a/main.go
+++ b/main.go
@@ -679,9 +679,7 @@ func (r *Rback) newClusterRoleNode(g *dot.Graph, bindingNamespace, roleName stri
 }
 
 func (r *Rback) isFocused(kind string, ns string, name string) bool {
-	return r.config.resourceKind == kind &&
-		(r.namespaceSelected(ns)) &&
-		contains(r.config.resourceNames, name)
+	return r.config.resourceKind == kind && r.namespaceSelected(ns) && r.resourceNameSelected(name)
 }
 
 func (r *Rback) resourceNameSelected(name string) bool {

--- a/main.go
+++ b/main.go
@@ -422,7 +422,7 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 		for _, sa := range serviceaccounts {
 			sanode, found := subjectNodes[KindNamespacedName{"ServiceAccount", NamespacedName{ns, sa}}]
 			if !found {
-				sanode = newServiceAccountNode(gns, sa)
+				sanode = newSubjectNode(gns, "ServiceAccount", sa)
 				subjectNodes[KindNamespacedName{"ServiceAccount", NamespacedName{ns, sa}}] = sanode
 			}
 
@@ -453,7 +453,7 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 						gns = r.newNamespaceSubgraph(g, subject.namespace)
 						nsSubgraphs[subject.namespace] = gns
 					}
-					subjectNode = newServiceAccountNode(gns, subject.name)
+					subjectNode = newSubjectNode(gns, subject.kind, subject.name)
 				}
 
 				saNodes = append(saNodes, subjectNode)
@@ -471,7 +471,7 @@ func (r *Rback) renderLegend(g *dot.Graph) {
 	namespace := legend.Subgraph("Namespace", dot.ClusterOption{})
 	namespace.Attr("style", "dashed")
 
-	sa := newServiceAccountNode(namespace, "ServiceAccount")
+	sa := newSubjectNode(namespace, "Kind", "Subject")
 
 	role := newRoleNode(namespace, "ns", "Role")
 	clusterRoleBoundLocally := newClusterRoleNode(namespace, "ns", "ClusterRole") // bound by (namespaced!) RoleBinding
@@ -550,10 +550,10 @@ func (r *Rback) newNamespaceSubgraph(g *dot.Graph, ns string) *dot.Graph {
 	return gns
 }
 
-func newServiceAccountNode(g *dot.Graph, name string) dot.Node {
-	return g.Node("sa-"+name).
+func newSubjectNode(g *dot.Graph, kind, name string) dot.Node {
+	return g.Node(kind+"-"+name).
 		Box().
-		Attr("label", name).
+		Attr("label", fmt.Sprintf("%s\n(%s)", name, kind)).
 		Attr("style", "filled").
 		Attr("fillcolor", "#2f6de1").
 		Attr("fontcolor", "#f0f0f0")

--- a/main.go
+++ b/main.go
@@ -211,36 +211,31 @@ func (r *Rback) getClusterScopedResources(kind string) (result map[string]string
 // fetchPermissions retrieves data about all access control related data
 // from service accounts to roles and bindings, both namespaced and the
 // cluster level.
-func (r *Rback) fetchPermissions() error {
-	sa, err := r.getServiceAccounts()
+func (r *Rback) fetchPermissions() (err error) {
+	r.permissions.ServiceAccounts, err = r.getServiceAccounts()
 	if err != nil {
 		return err
 	}
-	r.permissions.ServiceAccounts = sa
 
-	roles, err := r.getRoles()
+	r.permissions.Roles, err = r.getRoles()
 	if err != nil {
 		return err
 	}
-	r.permissions.Roles = roles
 
-	rb, err := r.getRoleBindings()
+	r.permissions.RoleBindings, err = r.getRoleBindings()
 	if err != nil {
 		return err
 	}
-	r.permissions.RoleBindings = rb
 
-	cr, err := r.getClusterRoles()
+	r.permissions.Roles[""], err = r.getClusterRoles()
 	if err != nil {
 		return err
 	}
-	r.permissions.Roles[""] = cr
 
-	crb, err := r.getClusterRoleBindings()
+	r.permissions.RoleBindings[""], err = r.getClusterRoleBindings()
 	if err != nil {
 		return err
 	}
-	r.permissions.RoleBindings[""] = crb
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -398,22 +398,6 @@ func (r *Rback) genGraph() *dot.Graph {
 	g.Attr("newrank", "true") // global rank instead of per-subgraph (ensures access rules are always in the same place (at bottom))
 	r.renderLegend(g)
 
-	if r.config.resourceKind == "" || r.config.resourceKind == "serviceaccount" {
-		for _, ns := range r.determineNamespacesToShow(r.permissions) {
-			gns := r.newNamespaceSubgraph(g, ns)
-
-			for sa, _ := range r.permissions.ServiceAccounts[ns] {
-				renderSA := (r.config.resourceKind == "") ||
-					((r.allNamespaces() || contains(r.config.namespaces, ns)) &&
-						(r.allResourceNames() || contains(r.config.resourceNames, sa)))
-				if renderSA {
-					r.newSubjectNode(gns, "ServiceAccount", ns, sa)
-				}
-			}
-		}
-	}
-
-	// roles:
 	for _, roleBindings := range r.permissions.RoleBindings {
 		bindings, err := r.lookupBindings(roleBindings, "", "")
 		if err != nil {
@@ -453,6 +437,22 @@ func (r *Rback) genGraph() *dot.Graph {
 			}
 		}
 	}
+
+	if r.config.resourceKind == "" || r.config.resourceKind == "serviceaccount" {
+		for _, ns := range r.determineNamespacesToShow(r.permissions) {
+			gns := r.newNamespaceSubgraph(g, ns)
+
+			for sa, _ := range r.permissions.ServiceAccounts[ns] {
+				renderSA := (r.config.resourceKind == "") ||
+					((r.allNamespaces() || contains(r.config.namespaces, ns)) &&
+						(r.allResourceNames() || contains(r.config.resourceNames, sa)))
+				if renderSA {
+					r.newSubjectNode(gns, "ServiceAccount", ns, sa)
+				}
+			}
+		}
+	}
+
 	return g
 }
 

--- a/main.go
+++ b/main.go
@@ -499,7 +499,9 @@ func (r *Rback) shouldRenderBinding(binding Binding) bool {
 			}
 		}
 	case "role":
-		return r.namespaceSelected(binding.role.namespace) &&
+		bindingPointsToClusterRole := binding.role.namespace == ""
+		return !bindingPointsToClusterRole &&
+			r.namespaceSelected(binding.role.namespace) &&
 			r.resourceNameSelected(binding.role.name) &&
 			r.roleExists(binding.role)
 	case "clusterrole":

--- a/main.go
+++ b/main.go
@@ -456,40 +456,45 @@ func struct2json(s map[string]interface{}) (string, error) {
 	return string(str), nil
 }
 
-func newServiceAccountNode(g *dot.Graph, id string) dot.Node {
-	return g.Node(id).
+func newServiceAccountNode(g *dot.Graph, name string) dot.Node {
+	return g.Node("sa-"+name).
 		Box().
+		Attr("label", name).
 		Attr("style", "filled").
 		Attr("fillcolor", "#2f6de1").
 		Attr("fontcolor", "#f0f0f0")
 }
 
-func newRoleBindingNode(g *dot.Graph, id string) dot.Node {
-	return g.Node(id).
+func newRoleBindingNode(g *dot.Graph, name string) dot.Node {
+	return g.Node("rb-"+name).
+		Attr("label", name).
 		Attr("shape", "octagon").
 		Attr("style", "filled").
 		Attr("fillcolor", "#ffcc00").
 		Attr("fontcolor", "#030303")
 }
 
-func newClusterRoleBindingNode(g *dot.Graph, id string) dot.Node {
-	return g.Node(id).
+func newClusterRoleBindingNode(g *dot.Graph, name string) dot.Node {
+	return g.Node("crb-"+name).
+		Attr("label", name).
 		Attr("shape", "doubleoctagon").
 		Attr("style", "filled").
 		Attr("fillcolor", "#ffcc00").
 		Attr("fontcolor", "#030303")
 }
 
-func newRoleNode(g *dot.Graph, id string) dot.Node {
-	return g.Node(id).
+func newRoleNode(g *dot.Graph, name string) dot.Node {
+	return g.Node("r-"+name).
+		Attr("label", name).
 		Attr("shape", "octagon").
 		Attr("style", "filled").
 		Attr("fillcolor", "#ff9900").
 		Attr("fontcolor", "#030303")
 }
 
-func newClusterRoleNode(g *dot.Graph, id string) dot.Node {
-	return g.Node(id).
+func newClusterRoleNode(g *dot.Graph, name string) dot.Node {
+	return g.Node("cr-"+name).
+		Attr("label", name).
 		Attr("shape", "doubleoctagon").
 		Attr("style", "filled").
 		Attr("fillcolor", "#ff9900").

--- a/main.go
+++ b/main.go
@@ -76,6 +76,8 @@ var kindMap = map[string]string{
 	"rolebindings":        "rolebinding",
 	"crb":                 "clusterrolebinding",
 	"clusterrolebindings": "clusterrolebinding",
+	"r":                   "role",
+	"roles":               "role",
 }
 
 func normalizeKind(kind string) string {
@@ -451,6 +453,8 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 						break
 					}
 				}
+			} else if r.config.resourceKind == "role" {
+				renderBinding = (allNamespaces || contains(r.config.namespaces, binding.role.namespace)) && (allResourceNames || contains(r.config.resourceNames, binding.role.name))
 			}
 
 			if !renderBinding {
@@ -472,6 +476,8 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 						renderSubject = true
 					} else if r.config.resourceKind == "serviceaccount" {
 						renderSubject = (allNamespaces || contains(r.config.namespaces, subject.namespace)) && (allResourceNames || contains(r.config.resourceNames, subject.name))
+					} else if r.config.resourceKind == "role" {
+						renderSubject = true
 					}
 
 					if renderSubject {

--- a/main.go
+++ b/main.go
@@ -267,13 +267,13 @@ type KindNamespacedName struct {
 }
 
 // lookupBindings lists bindings & roles for a given service account
-func (r *Rback) lookupBindings(bindings []string, saName, saNamespace string) (roles []Binding, err error) {
+func (r *Rback) lookupBindings(bindings []string, saName, saNamespace string) (results []Binding, err error) {
 	for _, rb := range bindings {
 		var binding map[string]interface{}
 		b := []byte(rb)
 		err = json.Unmarshal(b, &binding)
 		if err != nil {
-			return roles, err
+			return results, err
 		}
 
 		metadata := binding["metadata"].(map[string]interface{})
@@ -319,7 +319,7 @@ func (r *Rback) lookupBindings(bindings []string, saName, saNamespace string) (r
 					})
 				}
 
-				roles = append(roles, Binding{
+				results = append(results, Binding{
 					NamespacedName: NamespacedName{bindingNs, bindingName},
 					role:           NamespacedName{roleNs, roleName},
 					subjects:       subs,
@@ -327,7 +327,7 @@ func (r *Rback) lookupBindings(bindings []string, saName, saNamespace string) (r
 			}
 		}
 	}
-	return roles, nil
+	return results, nil
 }
 
 func stringOrEmpty(i interface{}) string {

--- a/main.go
+++ b/main.go
@@ -416,14 +416,14 @@ func (r *Rback) renderLegend(g *dot.Graph) {
 	}
 
 	if r.config.renderRules {
-		nsrules := newRulesNode(namespace, "Namespace-scoped\naccess rules")
+		nsrules := newRulesNode(namespace, "ns", "Role", "Namespace-scoped\naccess rules")
 		legend.Edge(role, nsrules)
 
-		nsrules2 := newRulesNode(namespace, "Namespace-scoped access rules From ClusterRole")
+		nsrules2 := newRulesNode(namespace, "ns", "ClusterRole", "Namespace-scoped access rules From ClusterRole")
 		nsrules2.Attr("label", "Namespace-scoped\naccess rules")
 		legend.Edge(clusterRoleBoundLocally, nsrules2)
 
-		clusterrules := newRulesNode(legend, "Cluster-scoped\naccess rules")
+		clusterrules := newRulesNode(legend, "", "ClusterRole", "Cluster-scoped\naccess rules")
 		legend.Edge(clusterrole, clusterrules)
 	}
 }
@@ -452,13 +452,13 @@ func (r *Rback) renderRole(g *dot.Graph, binding, role NamespacedName, saNode do
 	}
 
 	if r.config.renderRules {
-		res, err := r.lookupResources(binding.namespace, role.name, p)
+		rules, err := r.lookupResources(binding.namespace, role.name, p)
 		if err != nil {
 			fmt.Printf("Can't look up entities and resources due to: %v", err)
 			os.Exit(-3)
 		}
-		if res != "" {
-			resnode := newRulesNode(g, res)
+		if rules != "" {
+			resnode := newRulesNode(g, binding.namespace, role.name, rules)
 			g.Edge(roleNode, resnode)
 		}
 	}
@@ -518,7 +518,8 @@ func newClusterRoleNode(g *dot.Graph, namespace, name string) dot.Node {
 		Attr("fontcolor", "#030303")
 }
 
-func newRulesNode(g *dot.Graph, id string) dot.Node {
-	return g.Node(id).
+func newRulesNode(g *dot.Graph, namespace, roleName, rules string) dot.Node {
+	return g.Node("rules-"+namespace+"/"+roleName).
+		Attr("label", rules).
 		Attr("shape", "note")
 }

--- a/main.go
+++ b/main.go
@@ -26,11 +26,10 @@ type Config struct {
 }
 
 type Permissions struct {
-	ServiceAccounts     map[string]map[string]string // map[namespace]map[name]json
-	Roles               map[string]map[string]string
-	ClusterRoles        map[string]string
-	RoleBindings        map[string]map[string]string
-	ClusterRoleBindings map[string]string
+	ServiceAccounts map[string]map[string]string // map[namespace]map[name]json
+	Roles           map[string]map[string]string
+	ClusterRoles    map[string]string
+	RoleBindings    map[string]map[string]string // ClusterRoleBindings are stored in RoleBindings[""]
 }
 
 func main() {
@@ -242,7 +241,7 @@ func (r *Rback) fetchPermissions() error {
 	if err != nil {
 		return err
 	}
-	r.permissions.ClusterRoleBindings = crb
+	r.permissions.RoleBindings[""] = crb
 	return nil
 }
 
@@ -419,8 +418,6 @@ func (r *Rback) genGraph() *dot.Graph {
 			}
 		}
 	}
-
-	r.permissions.RoleBindings[""] = r.permissions.ClusterRoleBindings
 
 	// roles:
 	for _, roleBindings := range r.permissions.RoleBindings {

--- a/main.go
+++ b/main.go
@@ -479,7 +479,8 @@ func (r *Rback) shouldRenderBinding(binding Binding) bool {
 			r.resourceNameSelected(binding.role.name) &&
 			r.roleExists(binding.role)
 	case "clusterrole":
-		return (binding.role.namespace == "" || r.namespaceSelected(binding.role.namespace)) &&
+		bindingPointsToClusterRole := binding.role.namespace == ""
+		return bindingPointsToClusterRole &&
 			r.resourceNameSelected(binding.role.name) &&
 			r.roleExists(binding.role)
 	}

--- a/main.go
+++ b/main.go
@@ -78,6 +78,8 @@ var kindMap = map[string]string{
 	"clusterrolebindings": "clusterrolebinding",
 	"r":                   "role",
 	"roles":               "role",
+	"cr":                  "clusterrole",
+	"clusterroles":        "clusterrole",
 }
 
 func normalizeKind(kind string) string {
@@ -455,6 +457,8 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 				}
 			} else if r.config.resourceKind == "role" {
 				renderBinding = (allNamespaces || contains(r.config.namespaces, binding.role.namespace)) && (allResourceNames || contains(r.config.resourceNames, binding.role.name))
+			} else if r.config.resourceKind == "clusterrole" {
+				renderBinding = (binding.role.namespace == "" || allNamespaces || contains(r.config.namespaces, binding.role.namespace)) && (allResourceNames || contains(r.config.resourceNames, binding.role.name))
 			}
 
 			if !renderBinding {
@@ -477,6 +481,8 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 					} else if r.config.resourceKind == "serviceaccount" {
 						renderSubject = (allNamespaces || contains(r.config.namespaces, subject.namespace)) && (allResourceNames || contains(r.config.resourceNames, subject.name))
 					} else if r.config.resourceKind == "role" {
+						renderSubject = true
+					} else if r.config.resourceKind == "clusterrole" {
 						renderSubject = true
 					}
 

--- a/main.go
+++ b/main.go
@@ -410,10 +410,10 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 	allNamespaces := len(r.config.namespaces) == 1 && r.config.namespaces[0] == ""
 	allResourceNames := len(r.config.resourceNames) == 0
 
-	for _, ns := range r.determineNamespacesToShow(p) {
-		gns := r.existingOrNewNamespaceSubgraph(g, nsSubgraphs, ns)
+	if r.config.resourceKind == "" || r.config.resourceKind == "serviceaccount" {
+		for _, ns := range r.determineNamespacesToShow(p) {
+			gns := r.existingOrNewNamespaceSubgraph(g, nsSubgraphs, ns)
 
-		if r.config.resourceKind != "rolebinding" {
 			for _, sa := range p.ServiceAccounts[ns] {
 				sanode := r.existingOrNewSubjectNode(gns, subjectNodes, "ServiceAccount", ns, sa)
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ type Rback struct {
 
 type Config struct {
 	renderRules     bool
+	showLegend      bool
 	namespaces      []string
 	ignoredPrefixes []string
 	resourceKind    string
@@ -34,6 +35,7 @@ type Permissions struct {
 func main() {
 
 	config := Config{}
+	flag.BoolVar(&config.showLegend, "show-legend", true, "Whether to show the legend or not")
 	flag.BoolVar(&config.renderRules, "render-rules", true, "Whether to render RBAC rules (e.g. \"get pods\") or not")
 
 	var namespaces string
@@ -466,6 +468,10 @@ func (r *Rback) genGraph(p Permissions) *dot.Graph {
 }
 
 func (r *Rback) renderLegend(g *dot.Graph) {
+	if !r.config.showLegend {
+		return
+	}
+
 	legend := g.Subgraph("LEGEND", dot.ClusterOption{})
 
 	namespace := legend.Subgraph("Namespace", dot.ClusterOption{})

--- a/main.go
+++ b/main.go
@@ -157,9 +157,12 @@ func (r *Rback) getNamespacedResources(kind string) (result map[string][]string,
 	for _, i := range items {
 		item := i.(map[string]interface{})
 		metadata := item["metadata"].(map[string]interface{})
+		name := metadata["name"]
 		ns := metadata["namespace"]
-		itemJson, _ := struct2json(item)
-		result[ns.(string)] = append(result[ns.(string)], itemJson)
+		if !r.shouldIgnore(name.(string)) {
+			itemJson, _ := struct2json(item)
+			result[ns.(string)] = append(result[ns.(string)], itemJson)
+		}
 	}
 	return result, nil
 }

--- a/main.go
+++ b/main.go
@@ -689,7 +689,7 @@ func (r *Rback) newClusterRoleNode(g *dot.Graph, namespace, name string, highlig
 	return g.Node("cr-"+namespace+"/"+name).
 		Attr("label", name).
 		Attr("shape", "doubleoctagon").
-		Attr("style", "filled").
+		Attr("style", iff(namespace == "", "filled", "filled,dashed")).
 		Attr("penwidth", iff(highlight, "2.0", "1.0")).
 		Attr("fillcolor", "#ff9900").
 		Attr("fontcolor", "#030303")

--- a/main.go
+++ b/main.go
@@ -454,7 +454,10 @@ func (r *Rback) genGraph() *dot.Graph {
 				renderBinding = binding.namespace == "" && (allResourceNames || contains(r.config.resourceNames, binding.name))
 			} else if r.config.resourceKind == "serviceaccount" {
 				for _, subject := range binding.subjects {
-					if subject.kind == "ServiceAccount" && (allNamespaces || contains(r.config.namespaces, subject.namespace)) && (allResourceNames || contains(r.config.resourceNames, subject.name)) {
+					if subject.kind == "ServiceAccount" &&
+						(allNamespaces || contains(r.config.namespaces, subject.namespace)) &&
+						(allResourceNames || contains(r.config.resourceNames, subject.name)) &&
+						r.subjectExists("ServiceAccount", subject.namespace, subject.name) {
 						renderBinding = true
 						break
 					}

--- a/main.go
+++ b/main.go
@@ -445,7 +445,7 @@ func (r *Rback) genGraph() *dot.Graph {
 			gns := r.existingOrNewNamespaceSubgraph(g, binding.namespace)
 
 			bindingNode := r.newBindingNode(gns, binding)
-			roleNode := r.newRoleAndRulesNodePair(gns, binding.role)
+			roleNode := r.newRoleAndRulesNodePair(gns, binding.namespace, binding.role)
 
 			bindingNode.Edge(roleNode)
 
@@ -548,11 +548,11 @@ func (r *Rback) newBindingNode(gns *dot.Graph, binding Binding) dot.Node {
 	}
 }
 
-func (r *Rback) newRoleAndRulesNodePair(gns *dot.Graph, role NamespacedName) dot.Node {
+func (r *Rback) newRoleAndRulesNodePair(gns *dot.Graph, bindingNamespace string, role NamespacedName) dot.Node {
 	var roleNode dot.Node
 	isClusterRole := role.namespace == ""
 	if isClusterRole {
-		roleNode = r.newClusterRoleNode(gns, role.namespace, role.name, r.clusterRoleExists(role), r.isFocused("clusterrole", role.namespace, role.name))
+		roleNode = r.newClusterRoleNode(gns, bindingNamespace, role.name, r.clusterRoleExists(role), r.isFocused("clusterrole", role.namespace, role.name))
 	} else {
 		roleNode = r.newRoleNode(gns, role.namespace, role.name, r.roleExists(role), r.isFocused("role", role.namespace, role.name))
 	}
@@ -690,11 +690,11 @@ func (r *Rback) newRoleNode(g *dot.Graph, namespace, name string, exists, highli
 		Attr("fontcolor", "#030303")
 }
 
-func (r *Rback) newClusterRoleNode(g *dot.Graph, namespace, name string, exists, highlight bool) dot.Node {
-	return g.Node("cr-"+namespace+"/"+name).
-		Attr("label", name).
+func (r *Rback) newClusterRoleNode(g *dot.Graph, bindingNamespace, roleName string, exists, highlight bool) dot.Node {
+	return g.Node("cr-"+bindingNamespace+"/"+roleName).
+		Attr("label", roleName).
 		Attr("shape", "doubleoctagon").
-		Attr("style", iff(exists, iff(namespace == "", "filled", "filled,dashed"), "dotted")).
+		Attr("style", iff(exists, iff(bindingNamespace == "", "filled", "filled,dashed"), "dotted")).
 		Attr("color", iff(exists, "black", "red")).
 		Attr("penwidth", iff(highlight || !exists, "2.0", "1.0")).
 		Attr("fillcolor", "#ff9900").

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ type Rback struct {
 }
 
 type Config struct {
-	renderRules     bool
+	showRules       bool
 	showLegend      bool
 	namespaces      []string
 	ignoredPrefixes []string
@@ -37,7 +37,7 @@ func main() {
 
 	config := Config{}
 	flag.BoolVar(&config.showLegend, "show-legend", true, "Whether to show the legend or not")
-	flag.BoolVar(&config.renderRules, "render-rules", true, "Whether to render RBAC rules (e.g. \"get pods\") or not")
+	flag.BoolVar(&config.showRules, "show-rules", true, "Whether to render RBAC access rules (e.g. \"get pods\") or not")
 
 	var namespaces string
 	flag.StringVar(&namespaces, "n", "", "The namespace to render (also supports multiple, comma-delimited namespaces)")
@@ -592,7 +592,7 @@ func (r *Rback) renderLegend(g *dot.Graph) {
 	sa.Edge(clusterRoleBinding).Attr("dir", "back")
 	clusterRoleBinding.Edge(clusterrole)
 
-	if r.config.renderRules {
+	if r.config.showRules {
 		nsrules := newRulesNode(namespace, "ns", "Role", "Namespace-scoped\naccess rules")
 		legend.Edge(role, nsrules)
 
@@ -624,7 +624,7 @@ func (r *Rback) renderBindingAndRole(g *dot.Graph, binding, role NamespacedName)
 	}
 	roleBindingNode.Edge(roleNode)
 
-	if r.config.renderRules {
+	if r.config.showRules {
 		rules, err := r.lookupResources(binding.namespace, role.name)
 		if err != nil {
 			fmt.Printf("Can't look up entities and resources due to: %v", err)

--- a/main.go
+++ b/main.go
@@ -502,5 +502,6 @@ func newClusterRoleNode(g *dot.Graph, namespace, name string) dot.Node {
 }
 
 func newRulesNode(g *dot.Graph, id string) dot.Node {
-	return g.Node(id)
+	return g.Node(id).
+		Attr("shape", "note")
 }


### PR DESCRIPTION
This adds a bunch of new features:
- access rules are displayed in a much more human-friendly format
- can turn off rendering of access rules
- bindings are shown as nodes instead of edges
- can specify one or more namespaces with -n ns1,ns2
- can make one specific kind of resource main point of graph (for example: `rback rolebinding` will render rolebindings and only the subjects and (cluster)roles referenced by those rolebindings
- can specify one or more resource names (only the specified resource is shown plus all directly related resources)
- if a RoleBinding references a non-existent resource, the resource is drawn, but clearly marked as missing
- ClusterRoles/Bindings are drawn differently than namespaced Roles/Bindings
- if a (namespaced) RoleBinding references a ClusterRole, the ClusterRole is drawn inside the namespace, but with a dashed outline, so it's clear it is not part of the namespace (but its access rules apply inside the namespace)
- ignored prefixes are configurable (still default to `system:`)
- groups and users are also displayed (not just ServiceAccounts)